### PR TITLE
Text[Marshaler|Unmarshaler] support

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -99,6 +99,15 @@ func Cast(buf []byte) (Multihash, error) {
 	return Multihash(buf), nil
 }
 
+func (m Multihash) MarshalText() (text []byte, err error) {
+	return []byte(b58.Encode([]byte(m))), nil
+}
+
+func (m *Multihash) UnmarshalText(text []byte) error {
+	*m = b58.Decode(string(text))
+	return nil
+}
+
 // Decodes a hash from the given Multihash.
 func Decode(buf []byte) (*DecodedMultihash, error) {
 

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -190,3 +190,38 @@ func TestHex(t *testing.T) {
 		}
 	}
 }
+
+func TestTextMarshalerUnmarshaler(t *testing.T) {
+	mh1, mh2 := new(Multihash), new(Multihash)
+	for _, tc := range testCases {
+		b, _ := hex.DecodeString(tc.hex)
+		*mh1 = b
+
+		text, err := mh1.MarshalText()
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		err = mh2.UnmarshalText(text)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if mh2.HexString() != tc.hex {
+			t.Errorf("Marshal/UnmarshalText produced inconsistant results,\nwanted %q, got %q", tc.hex, mh2.HexString())
+		}
+
+	}
+}
+
+func BenchmarkMarshalUnmarshal(b *testing.B) {
+	mh := new(Multihash)
+	for i := 0; i < b.N; i++ {
+		*mh, _ = Sum(*mh, SHA3, -1)
+
+		text, _ := mh.MarshalText()
+		mh.UnmarshalText(text)
+	}
+}


### PR DESCRIPTION
This add two functions that allow encoders like JSON to encode and decode multihashes.
The receiver type is a pointer because encoders cannot change the size of a bare slice.

I chose to use hex encoding because it was significantly faster than base58.