### PR TITLE
Added SHA-3 test cases

### DIFF
--- a/sum_test.go
+++ b/sum_test.go
@@ -19,6 +19,8 @@ var sumTestCases = []SumTestCase{
 	SumTestCase{SHA2_256, 16, "foo", "12102c26b46b68ffc68ff99b453c1d304134"},
 	SumTestCase{SHA2_512, -1, "foo", "1340f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"},
 	SumTestCase{SHA2_512, 32, "foo", "1320f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc663832"},
+	SumTestCase{SHA3, -1, "foo", "14404bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"},
+	SumTestCase{SHA3, 32, "foo", "14204bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c"},
 }
 
 func TestSum(t *testing.T) {


### PR DESCRIPTION
All of the other hash algorithms had test cases. Created two equivalent ones for SHA-3. Reference hashes were generated with http://emn178.github.io/online-tools/sha3_512.html and the tests still pass.